### PR TITLE
Don't use NPX in the release process

### DIFF
--- a/.github/workflows/deploy_on_release.yaml
+++ b/.github/workflows/deploy_on_release.yaml
@@ -21,7 +21,7 @@ jobs:
         run: npm ci && npm --prefix functions ci
 
       - name: Build project
-        run: npm run build && npm --prefix functions build
+        run: npm run build && npm --prefix functions run build
 
       - name: Deploy to Firebase
         run: npx firebase deploy --token "$FIREBASE_TOKEN"

--- a/.github/workflows/deploy_on_release.yaml
+++ b/.github/workflows/deploy_on_release.yaml
@@ -18,12 +18,12 @@ jobs:
           node-version: '22'
 
       - name: Install dependencies
-        run: npm ci && npm --prefix functions ci
+        run: npm ci && npm --prefix functions ci && npm i -g firebase-tools
 
       - name: Build project
         run: npm run build && npm --prefix functions run build
 
       - name: Deploy to Firebase
-        run: npx firebase deploy --token "$FIREBASE_TOKEN"
+        run: firebase deploy --token "$FIREBASE_TOKEN"
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
For whatever reason, it really doesn't like `firebase`, so this just installs Firebase tools globally instead.