### PR TITLE
Make negative balances count toward allocation

### DIFF
--- a/src/app/components/accounts/account-summary/account-summary.ts
+++ b/src/app/components/accounts/account-summary/account-summary.ts
@@ -21,7 +21,10 @@ export class AccountSummary {
   protected readonly allocatedAmount = computed<number>(() => {
     let sum = 0.0;
     for (const category of this.account().categories) {
-      sum += category.balance;
+      // Ironically, we want to count negative balances *towards* the allocated
+      // amount, because the user has to cover for that number somewhere,
+      // somehow.
+      sum += Math.abs(category.balance);
     }
     return sum;
   });


### PR DESCRIPTION
Makes negative balances count *positively* toward allocation since the user will need to cover that balance in that budget line somehow.

Closes #14 