### PR TITLE
Add various account sum numbers in the UI

### DIFF
--- a/src/app/components/accounts/account-list/account-list.html
+++ b/src/app/components/accounts/account-list/account-list.html
@@ -1,5 +1,5 @@
 <ul>
-  @for (account of accounts(); track account.account.id) {
+  @for (account of accountData.accounts(); track account.account.id) {
     <li>
       <ya-account-summary [account]="account" />
     </li>

--- a/src/app/components/accounts/account-list/account-list.ts
+++ b/src/app/components/accounts/account-list/account-list.ts
@@ -1,10 +1,7 @@
-import {Category} from 'ynab';
-import {Component, inject, computed} from '@angular/core';
+import {Component, inject} from '@angular/core';
 
-import {AccountSummary, AccountAllocation} from '../account-summary/account-summary';
-import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
-import {FirestoreStorage} from '../../../../lib/firestore/firestore_storage';
-import {Allocation} from '../../../../lib/models/allocation';
+import {AccountSummary} from '../account-summary/account-summary';
+import {AccountData} from '../../../../lib/accounts/account_data';
 
 @Component({
   selector: 'ya-account-list',
@@ -13,49 +10,5 @@ import {Allocation} from '../../../../lib/models/allocation';
   imports: [AccountSummary],
 })
 export class AccountList {
-  private readonly ynabStorage = inject(YnabStorage);
-  private readonly firestoreStorage = inject(FirestoreStorage);
-
-  protected readonly accounts = computed<AccountAllocation[]>(() => {
-    const accounts = this.ynabStorage.accounts.value() ?? [];
-    if (accounts.length < 1) return [];
-
-    const allocations = this.firestoreStorage.allocations();
-
-    const allocationsMap = new Map<AccountId, Allocation[]>();
-    for (const allocation of allocations) {
-      if (!allocationsMap.has(allocation.accountId)) {
-        allocationsMap.set(allocation.accountId, [allocation]);
-        continue;
-      }
-
-      allocationsMap.get(allocation.accountId)!.push(allocation);
-    }
-
-    const groups = this.ynabStorage.latestCategories.value() ?? [];
-    const categories = groups.flatMap((v) => v.categories);
-    const categoriesMap = new Map<CategoryId, Category>();
-    for (const category of categories) {
-      categoriesMap.set(category.id, category);
-    }
-
-    return accounts.map((account) => {
-      const allocations = allocationsMap.get(account.id) ?? [];
-      const accountCategories: Category[] = [];
-      for (const allocation of allocations) {
-        const category = categoriesMap.get(allocation.categoryId);
-        if (!category) continue;
-
-        accountCategories.push(category);
-      }
-
-      return {
-        account,
-        categories: accountCategories,
-      };
-    });
-  });
+  protected readonly accountData = inject(AccountData);
 }
-
-type AccountId = string;
-type CategoryId = string;

--- a/src/app/components/accounts/account-summary/account-summary.html
+++ b/src/app/components/accounts/account-summary/account-summary.html
@@ -42,7 +42,7 @@
       [theme]="allocationsTheme()"
       [flat]="!hasAllocations()">
     <div label class="allocation-label">
-      <ya-currency [milliunits]="allocatedAmount()" />
+      <ya-currency [milliunits]="account().total" />
       &sol;
       <ya-currency [milliunits]="account().account.cleared_balance" />
     </div>
@@ -55,7 +55,7 @@
 
         <div class="allocated">-</div>
         <div class="allocated">Allocated ({{ account().categories.length }}):</div>
-        <ya-currency class="allocated" [milliunits]="allocatedAmount()" />
+        <ya-currency class="allocated" [milliunits]="account().total" />
 
         <div>=</div>
         <div>&nbsp;</div>

--- a/src/app/components/accounts/account-summary/account-summary.ts
+++ b/src/app/components/accounts/account-summary/account-summary.ts
@@ -1,11 +1,10 @@
 import {Component, input, computed, inject} from '@angular/core';
-import {Account, Category} from 'ynab';
 
 import {CurrencyCopyButton} from '../../common/currency-copy-button/currency-copy-button';
 import {Currency} from '../../common/currency/currency';
 import {DropdownButton, ButtonTheme} from '../../common/dropdown-button/dropdown-button';
 import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
-import {SettingsStorage} from '../../../../lib/firebase/settings_storage';
+import {AccountAllocation} from '../../../../lib/accounts/account_data';
 
 @Component({
   selector: 'ya-account-summary',
@@ -20,18 +19,8 @@ import {SettingsStorage} from '../../../../lib/firebase/settings_storage';
 export class AccountSummary {
   readonly account = input.required<AccountAllocation>();
 
-  protected readonly allocatedAmount = computed<number>(() => {
-    let sum = 0;
-    for (const category of this.account().categories) {
-      // We always take a positive value here because negative values still need
-      // to be covered somehow.
-      sum += Math.abs(category.balance);
-    }
-    return sum;
-  });
-
   protected readonly delta = computed<number>(() => {
-    return this.account().account.cleared_balance - this.allocatedAmount();
+    return this.account().account.cleared_balance - this.account().total;
   });
 
   protected readonly hasAllocations = computed<boolean>(() => {
@@ -52,12 +41,4 @@ export class AccountSummary {
   });
 
   private readonly ynabStorage = inject(YnabStorage);
-}
-
-/**
- * The special data structure that this component renders.
- */
-export interface AccountAllocation {
-  readonly account: Account;
-  readonly categories: Category[];
 }

--- a/src/app/components/accounts/accounts-summary/accounts-summary.html
+++ b/src/app/components/accounts/accounts-summary/accounts-summary.html
@@ -1,0 +1,30 @@
+<div class="number-section">
+  <ya-dropdown-button dropdownLabel="Available" [flat]="true">
+    <span label>
+      <ya-currency [milliunits]="accountData.availableCash()" />
+    </span>
+
+    <p dropdown class="info">
+      You have <b><ya-currency [milliunits]="accountData.availableCash()" /></b>
+      available after all allocations, across all of your budgeting accounts.
+    </p>
+  </ya-dropdown-button>
+
+  <p class="label">Available</p>
+</div>
+
+<div class="number-section">
+  <ya-dropdown-button dropdownLabel="Total balance" [flat]="true">
+    <span label>
+      <ya-currency [milliunits]="accountData.totalAvailable()" />
+    </span>
+
+    <p dropdown class="info">
+      Your accounts have a total of
+      <b><ya-currency [milliunits]="accountData.totalAvailable()" /></b>
+      in them <i>before</i> any allocations are subtracted.
+    </p>
+  </ya-dropdown-button>
+
+  <p class="label">Balance</p>
+</div>

--- a/src/app/components/accounts/accounts-summary/accounts-summary.scss
+++ b/src/app/components/accounts/accounts-summary/accounts-summary.scss
@@ -1,0 +1,29 @@
+:host {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 20px;
+}
+
+.info {
+  margin: 0;
+  padding: 4px 20px 20px;
+  max-width: 300px;
+}
+
+.number-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+  justify-content: center;
+
+  .label {
+    padding: 0;
+    margin: 0;
+    text-align: center;
+    font-size: 12px;
+    text-transform: uppercase;
+  }
+}

--- a/src/app/components/accounts/accounts-summary/accounts-summary.spec.ts
+++ b/src/app/components/accounts/accounts-summary/accounts-summary.spec.ts
@@ -1,0 +1,25 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {AccountsSummary} from './accounts-summary';
+import {provideZonelessChangeDetection} from '@angular/core';
+
+describe('AccountsSummary', () => {
+  let component: AccountsSummary;
+  let fixture: ComponentFixture<AccountsSummary>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AccountsSummary],
+      providers: [provideZonelessChangeDetection()],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AccountsSummary);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/accounts/accounts-summary/accounts-summary.ts
+++ b/src/app/components/accounts/accounts-summary/accounts-summary.ts
@@ -1,0 +1,15 @@
+import {Component, inject} from '@angular/core';
+
+import {AccountData} from '../../../../lib/accounts/account_data';
+import {DropdownButton} from '../../common/dropdown-button/dropdown-button';
+import {Currency} from "../../common/currency/currency";
+
+@Component({
+  selector: 'ya-accounts-summary',
+  templateUrl: './accounts-summary.html',
+  styleUrl: './accounts-summary.scss',
+  imports: [DropdownButton, Currency],
+})
+export class AccountsSummary {
+  protected readonly accountData = inject(AccountData);
+}

--- a/src/app/components/allocations/total-allocations-button/total-allocations-button.html
+++ b/src/app/components/allocations/total-allocations-button/total-allocations-button.html
@@ -1,0 +1,10 @@
+<ya-dropdown-button dropdownLabel="Total allocated" [flat]="true" icon="functions">
+  <span label>
+    <ya-currency [milliunits]="accountData.totalAllocated()" />
+  </span>
+
+  <p dropdown class="info">
+    You have <b><ya-currency [milliunits]="accountData.totalAllocated()" /></b>
+    allocated across all of your categories.
+  </p>
+</ya-dropdown-button>

--- a/src/app/components/allocations/total-allocations-button/total-allocations-button.scss
+++ b/src/app/components/allocations/total-allocations-button/total-allocations-button.scss
@@ -1,0 +1,9 @@
+:host {
+  display: contents;
+}
+
+.info {
+  padding: 4px 20px 20px;
+  max-width: 300px;
+  margin: 0;
+}

--- a/src/app/components/allocations/total-allocations-button/total-allocations-button.spec.ts
+++ b/src/app/components/allocations/total-allocations-button/total-allocations-button.spec.ts
@@ -1,0 +1,25 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {TotalAllocationsButton} from './total-allocations-button';
+import {provideZonelessChangeDetection} from '@angular/core';
+
+describe('TotalAllocationsButton', () => {
+  let component: TotalAllocationsButton;
+  let fixture: ComponentFixture<TotalAllocationsButton>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TotalAllocationsButton],
+      providers: [provideZonelessChangeDetection()],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(TotalAllocationsButton);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/allocations/total-allocations-button/total-allocations-button.ts
+++ b/src/app/components/allocations/total-allocations-button/total-allocations-button.ts
@@ -1,0 +1,14 @@
+import {Component, inject} from '@angular/core';
+import {DropdownButton} from '../../common/dropdown-button/dropdown-button';
+import {AccountData} from '../../../../lib/accounts/account_data';
+import {Currency} from "../../common/currency/currency";
+
+@Component({
+  selector: 'ya-total-allocations-button',
+  templateUrl: './total-allocations-button.html',
+  styleUrl: './total-allocations-button.scss',
+  imports: [DropdownButton, Currency],
+})
+export class TotalAllocationsButton {
+  protected readonly accountData = inject(AccountData);
+}

--- a/src/app/pages/app/app.html
+++ b/src/app/pages/app/app.html
@@ -44,6 +44,8 @@
 
     <div class="header">
       <h2 class="label">Categories</h2>
+
+      <ya-total-allocations-button />
     </div>
 
     <ya-category-list />

--- a/src/app/pages/app/app.html
+++ b/src/app/pages/app/app.html
@@ -33,6 +33,8 @@
       <ya-month-selector />
     </div>
 
+    <ya-accounts-summary />
+
     <ya-account-list />
   </div>
 

--- a/src/app/pages/app/app.ts
+++ b/src/app/pages/app/app.ts
@@ -1,6 +1,7 @@
 import {BudgetSummary} from 'ynab';
 import {Component, inject, ElementRef, signal, effect} from '@angular/core';
 
+import {AccountData} from '../../../lib/accounts/account_data';
 import {AccountList} from '../../components/accounts/account-list/account-list';
 import {BetaInfoButton} from '../../components/common/beta-info-button/beta-info-button';
 import {BudgetSelectorButton} from '../../components/budgets/budget-selector-button/budget-selector-button';
@@ -10,6 +11,7 @@ import {LogoutButton} from '../../components/auth/logout-button/logout-button';
 import {MonthSelector} from "../../components/common/month-selector/month-selector";
 import {SettingsButton} from '../../components/settings/settings-button/settings-button';
 import {SettingsStorage} from '../../../lib/firebase/settings_storage';
+import {TotalAllocationsButton} from "../../components/allocations/total-allocations-button/total-allocations-button";
 import {YnabStorage, YnabStorageStatus} from '../../../lib/ynab/ynab_storage';
 
 @Component({
@@ -25,11 +27,13 @@ import {YnabStorage, YnabStorageStatus} from '../../../lib/ynab/ynab_storage';
     LogoutButton,
     MonthSelector,
     SettingsButton,
+    TotalAllocationsButton,
   ],
 })
 export class AppPage {
   protected readonly ynabStorage = inject(YnabStorage);
   protected readonly settingsStorage = inject(SettingsStorage);
+  protected readonly accountData = inject(AccountData);
 
   protected readonly loading = signal<boolean>(false);
   protected readonly YnabStorageStatus = YnabStorageStatus;

--- a/src/app/pages/app/app.ts
+++ b/src/app/pages/app/app.ts
@@ -3,6 +3,7 @@ import {Component, inject, ElementRef, signal, effect} from '@angular/core';
 
 import {AccountData} from '../../../lib/accounts/account_data';
 import {AccountList} from '../../components/accounts/account-list/account-list';
+import {AccountsSummary} from '../../components/accounts/accounts-summary/accounts-summary';
 import {BetaInfoButton} from '../../components/common/beta-info-button/beta-info-button';
 import {BudgetSelectorButton} from '../../components/budgets/budget-selector-button/budget-selector-button';
 import {CategoryList} from '../../components/categories/category-list/category-list';
@@ -20,6 +21,7 @@ import {YnabStorage, YnabStorageStatus} from '../../../lib/ynab/ynab_storage';
   styleUrl: './app.scss',
   imports: [
     AccountList,
+    AccountsSummary,
     BetaInfoButton,
     BudgetSelectorButton,
     CategoryList,

--- a/src/lib/accounts/account_data.ts
+++ b/src/lib/accounts/account_data.ts
@@ -1,0 +1,70 @@
+import {computed, Injectable, inject} from "@angular/core";
+import {Account, Category} from "ynab";
+
+import {YnabStorage} from "../ynab/ynab_storage";
+import {FirestoreStorage} from "../firestore/firestore_storage";
+import {Allocation} from "../models/allocation";
+
+/**
+ * Contains pre-computed signals for common account information.
+ */
+@Injectable({providedIn: "root"})
+export class AccountData {
+  readonly accounts = computed<AccountAllocation[]>(() => {
+    const accounts = this.ynabStorage.accounts.value() ?? [];
+    if (accounts.length < 1) return [];
+
+    const allocations = this.firestoreStorage.allocations();
+
+    const allocationsMap = new Map<AccountId, Allocation[]>();
+    for (const allocation of allocations) {
+      if (!allocationsMap.has(allocation.accountId)) {
+        allocationsMap.set(allocation.accountId, [allocation]);
+        continue;
+      }
+
+      allocationsMap.get(allocation.accountId)!.push(allocation);
+    }
+
+    const groups = this.ynabStorage.latestCategories.value() ?? [];
+    const categories = groups.flatMap((v) => v.categories);
+    const categoriesMap = new Map<CategoryId, Category>();
+    for (const category of categories) {
+      categoriesMap.set(category.id, category);
+    }
+
+    return accounts.map((account) => {
+      const allocations = allocationsMap.get(account.id) ?? [];
+      const accountCategories: Category[] = [];
+      let sum = 0;
+      for (const allocation of allocations) {
+        const category = categoriesMap.get(allocation.categoryId);
+        if (!category) continue;
+
+        accountCategories.push(category);
+        sum += category.balance;
+      }
+
+      return {
+        account,
+        categories: accountCategories,
+        total: sum,
+      };
+    });
+  });
+
+  private readonly ynabStorage = inject(YnabStorage);
+  private readonly firestoreStorage = inject(FirestoreStorage);
+}
+
+/**
+ * Summarizes the allocation for a given account.
+ */
+export interface AccountAllocation {
+  readonly account: Account;
+  readonly categories: Category[];
+  readonly total: number;
+}
+
+type AccountId = string;
+type CategoryId = string;

--- a/src/lib/accounts/account_data.ts
+++ b/src/lib/accounts/account_data.ts
@@ -10,6 +10,10 @@ import {Allocation} from "../models/allocation";
  */
 @Injectable({providedIn: "root"})
 export class AccountData {
+  /**
+   * All of the user's active accounts, with summary information for their
+   * allocations.
+   */
   readonly accounts = computed<AccountAllocation[]>(() => {
     const accounts = this.ynabStorage.accounts.value() ?? [];
     if (accounts.length < 1) return [];
@@ -51,6 +55,35 @@ export class AccountData {
         total: sum,
       };
     });
+  });
+
+  /**
+   * The total amount of allocated money across all accounts.
+   */
+  readonly totalAllocated = computed<number>(() => {
+    let sum = 0;
+    for (const account of this.accounts()) {
+      sum += account.total;
+    }
+    return sum;
+  });
+
+  /**
+   * The total available money (cleared) across all accounts.
+   */
+  readonly totalAvailable = computed<number>(() => {
+    let sum = 0;
+    for (const account of this.accounts()) {
+      sum += account.account.cleared_balance;
+    }
+    return sum;
+  });
+
+  /**
+   * The total remaining available cash after all allocations.
+   */
+  readonly availableCash = computed<number>(() => {
+    return this.totalAvailable() - this.totalAllocated();
   });
 
   private readonly ynabStorage = inject(YnabStorage);


### PR DESCRIPTION
This adds three new sums on the page for the user:

-   Total balance across all accounts (before allocations)
-   Total remaining balance across all accounts (after allocations)
-   Total allocated

Closes #17