### PR TITLE
Add absolute splits to the app

### DIFF
--- a/src/app/components/allocations/allocation-selector/allocation-selector.html
+++ b/src/app/components/allocations/allocation-selector/allocation-selector.html
@@ -1,19 +1,42 @@
 <ya-dropdown-button
-    dropdownLabel="Allocate to:"
+    [dropdownLabel]="splitMode() ? 'Allocate to accounts' : 'Allocate to account'"
     [menuItems]="menuItems()"
-    [flat]="allocatedAccount() === null">
-  <span label>
-    @if (allocatedAccount() === null) {
-      -
-    } @else {
-      {{ allocatedAccount()!.name }}
-    }
-  </span>
+    [flat]="allocatedAccount() === null"
+    [noClose]="splitMode()">
+  <span label>{{ label() }}</span>
 
-  @if (allocatedAccount() !== null) {
-    <div dropdown class="dropdown">
-        <button class="ya-button flat" (click)="selectAccount(null)">Clear</button>
+  <div dropdown class="dropdown" [class.split-mode]="splitMode()">
+    <div class="actions">
+      <button class="ya-button flat" (click)="toggleSplitMode()">
+        @if (splitMode()) {
+          <mat-icon inline aria-hidden="true">merge</mat-icon>
+          Single
+        } @else {
+          <mat-icon inline aria-hidden="true">call_split</mat-icon>
+          Split
+        }
+      </button>
+
+      @if (splitMode()) {
+        <button class="ya-button flat site-theme" (click)="applySplit()">
+          <mat-icon inline aria-hidden="true">done</mat-icon>
+          Apply
+        </button>
+      }
+
+      <button class="ya-button flat"
+          [disabled]="allocatedAccount() === null"
+          (click)="selectAccount(null)">
+        <mat-icon inline aria-hidden="true">clear</mat-icon>
+        Clear
+      </button>
     </div>
-  }
+
+    @if (splitMode()) {
+      <ya-split-selector [allocation]="allocation()" />
+
+      <h3 class="default-header">Default account:</h3>
+    }
+  </div>
 </ya-dropdown-button>
 

--- a/src/app/components/allocations/allocation-selector/allocation-selector.scss
+++ b/src/app/components/allocations/allocation-selector/allocation-selector.scss
@@ -3,7 +3,23 @@
 }
 
 .dropdown {
-  display: flex;
-  justify-content: center;
-  padding: 20px;
+  padding: 8px 20px 20px;
+
+  &.split-mode {
+    padding: 8px 20px 0;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+  }
+}
+
+.default-header {
+  text-align: center;
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+  padding: 4px 0;
 }

--- a/src/app/components/allocations/allocation-selector/allocation-selector.ts
+++ b/src/app/components/allocations/allocation-selector/allocation-selector.ts
@@ -1,21 +1,24 @@
-import {Component, inject, input, computed, ViewChild} from '@angular/core';
+import {Component, inject, input, computed, ViewChild, signal, effect} from '@angular/core';
+import {MatIcon} from '@angular/material/icon';
 import {Account, Category} from 'ynab';
 
 import {AbsoluteSplitAllocation, Allocation, SingleAllocation} from '../../../../lib/models/allocation';
 import {DropdownButton, DropdownMenuItem} from '../../common/dropdown-button/dropdown-button';
 import {FirestoreStorage} from '../../../../lib/firestore/firestore_storage';
 import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
+import {SplitSelector} from '../split-selector/split-selector';
 
 @Component({
   selector: 'ya-allocation-selector',
   templateUrl: './allocation-selector.html',
   styleUrl: './allocation-selector.scss',
-  imports: [DropdownButton],
+  imports: [DropdownButton, MatIcon, SplitSelector],
 })
 export class AllocationSelector {
   readonly category = input.required<Category>();
 
   @ViewChild(DropdownButton) dropdownButton!: DropdownButton<Account>;
+  @ViewChild(SplitSelector) splitSelector!: SplitSelector;
 
   /**
    * The currently selected allocation. Instead of keeping some local copy
@@ -40,15 +43,20 @@ export class AllocationSelector {
     const allocation = this.allocation();
     if (allocation === null) return null;
 
-    // TODO: Render something more interesting here
-    if (allocation instanceof AbsoluteSplitAllocation) return null;
-    if (!(allocation instanceof SingleAllocation)) return null;
+    let accountId: string;
+    if (allocation instanceof AbsoluteSplitAllocation) {
+      accountId = allocation.defaultAccountId;
+    } else if (allocation instanceof SingleAllocation) {
+      accountId = allocation.accountId;
+    } else {
+      return null;
+    }
 
     const accounts = this.ynabStorage.accounts.value();
     if (!accounts) return null;
 
     for (const account of accounts) {
-      if (account.id === allocation.accountId) {
+      if (account.id === accountId) {
         return account;
       }
     }
@@ -56,13 +64,29 @@ export class AllocationSelector {
     return null;
   });
 
+  protected readonly label = computed<string>(() => {
+    const allocation = this.allocation();
+    if (!allocation) return '-';
+
+    const allocatedName = this.allocatedAccount()?.name ?? '?';
+    if (allocation instanceof SingleAllocation) {
+      return allocatedName;
+    } else if (allocation instanceof AbsoluteSplitAllocation) {
+      return `${allocatedName} (+${allocation.splits.length})`;
+    } else {
+      return '??';
+    }
+  });
+
   protected readonly menuItems = computed<DropdownMenuItem<Account>[]>(() => {
     const accounts = this.ynabStorage.accounts.value();
     if (!accounts) return [];
 
+    const selectedAccount = this.splitMode() ? this.splitState.defaultAccount() : this.allocatedAccount();
+
     return accounts.map((a) => ({
       label: a.name,
-      icon: this.allocatedAccount() === a ? 'done' : 'account_balance',
+      icon: selectedAccount === a ? 'done' : 'account_balance',
       value: a,
       action: (value: Account) => {
         this.selectAccount(value);
@@ -70,22 +94,69 @@ export class AllocationSelector {
     }));
   });
 
+  protected readonly splitMode = signal<boolean>(false);
+  protected readonly splitState = {
+    defaultAccount: signal<Account | null>(null),
+  };
   protected readonly ynabStorage = inject(YnabStorage);
 
   private readonly firestoreStorage = inject(FirestoreStorage);
 
-  protected async selectAccount(account: Account | null) {
-    const budget = this.ynabStorage.selectedBudget();
-    if (budget === null) return;
+  constructor() {
+    // Update the splitMode based on the current allocation.
+    effect(() => {
+      const allocation = this.allocation();
 
+      if (allocation instanceof AbsoluteSplitAllocation) {
+        this.splitMode.set(true);
+        const defaultAccount = this.ynabStorage.findAccount(allocation.defaultAccountId);
+        if (defaultAccount) {
+          this.splitState.defaultAccount.set(defaultAccount);
+        }
+      } else if (allocation instanceof SingleAllocation) {
+        this.splitMode.set(false);
+      }
+    });
+  }
+
+  protected async selectAccount(account: Account | null) {
     if (account === null) {
       await this.firestoreStorage.clearAllocationForCategory(this.category());
       this.dropdownButton.close();
       return;
     }
 
+    if (this.splitMode()) {
+      this.splitState.defaultAccount.set(account);
+      return;
+    }
+
+    const budget = this.ynabStorage.selectedBudget();
+    if (budget === null) return;
+
     const newAllocation = new SingleAllocation(budget.id, this.category().id, account.id);
     await this.firestoreStorage.upsertAllocation(newAllocation);
+    this.dropdownButton.close();
+  }
+
+  protected toggleSplitMode() {
+    this.splitMode.update((s) => !s);
+  }
+
+  protected async applySplit() {
+    const splits = this.splitSelector.getEntries();
+    const defaultAccount = this.splitState.defaultAccount();
+    const budget = this.ynabStorage.selectedBudget();
+    if (!budget) return;
+    if (!defaultAccount) return;
+
+    const allocation = new AbsoluteSplitAllocation(
+        budget.id,
+        this.category().id,
+        defaultAccount.id,
+        splits);
+    await this.firestoreStorage.upsertAllocation(allocation);
+
     this.dropdownButton.close();
   }
 }

--- a/src/app/components/allocations/allocation-selector/allocation-selector.ts
+++ b/src/app/components/allocations/allocation-selector/allocation-selector.ts
@@ -1,7 +1,7 @@
 import {Component, inject, input, computed, ViewChild} from '@angular/core';
 import {Account, Category} from 'ynab';
 
-import {Allocation} from '../../../../lib/models/allocation';
+import {AbsoluteSplitAllocation, Allocation, SingleAllocation} from '../../../../lib/models/allocation';
 import {DropdownButton, DropdownMenuItem} from '../../common/dropdown-button/dropdown-button';
 import {FirestoreStorage} from '../../../../lib/firestore/firestore_storage';
 import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
@@ -39,6 +39,10 @@ export class AllocationSelector {
   protected readonly allocatedAccount = computed<Account | null>(() => {
     const allocation = this.allocation();
     if (allocation === null) return null;
+
+    // TODO: Render something more interesting here
+    if (allocation instanceof AbsoluteSplitAllocation) return null;
+    if (!(allocation instanceof SingleAllocation)) return null;
 
     const accounts = this.ynabStorage.accounts.value();
     if (!accounts) return null;
@@ -80,7 +84,7 @@ export class AllocationSelector {
       return;
     }
 
-    const newAllocation = new Allocation(budget.id, this.category().id, account.id);
+    const newAllocation = new SingleAllocation(budget.id, this.category().id, account.id);
     await this.firestoreStorage.upsertAllocation(newAllocation);
     this.dropdownButton.close();
   }

--- a/src/app/components/allocations/split-selector/split-selector.html
+++ b/src/app/components/allocations/split-selector/split-selector.html
@@ -1,0 +1,32 @@
+<div class="split">
+  <div>Account</div>
+  <div>Amount</div>
+  <div>&nbsp;</div>
+</div>
+
+@for (split of splits(); track split; let i = $index) {
+  <div class="split">
+    <select [formControl]="split.account">
+      <option [ngValue]="null">Select account:</option>
+      @for (account of ynabStorage.accounts.value(); track account.id) {
+        <option [ngValue]="account">{{ account.name }}</option>
+      }
+    </select>
+
+    <input type="text" [formControl]="split.amount" />
+
+    <!--
+      For some strange reason, if this is a button, it will close the
+      enclosing matmenu when clicked, and no amount of preventDefault() and
+      similar will stop it. Even weirder is the button outside this for
+      loop doesn't have that problem. So, for now this is a span until someone
+      figures out why that happens. -->
+    <span role="button" class="ya-button flat" (click)="removeSplit($event, i)">
+      <mat-icon inline>delete</mat-icon>
+    </span>
+  </div>
+}
+
+<button class="ya-button flat add-button" (click)="addSplit()">
+  <mat-icon inline>add</mat-icon>
+</button>

--- a/src/app/components/allocations/split-selector/split-selector.scss
+++ b/src/app/components/allocations/split-selector/split-selector.scss
@@ -1,0 +1,14 @@
+:host {
+  display: grid;
+  grid-template-columns: 1fr 1fr min-content;
+  align-items: center;
+  gap: 6px;
+}
+
+.split {
+  display: contents;
+}
+
+.add-button {
+  grid-column: 3 / 4;
+}

--- a/src/app/components/allocations/split-selector/split-selector.spec.ts
+++ b/src/app/components/allocations/split-selector/split-selector.spec.ts
@@ -1,0 +1,25 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideZonelessChangeDetection} from '@angular/core';
+
+import {SplitSelector} from './split-selector';
+
+describe('SplitSelector', () => {
+  let component: SplitSelector;
+  let fixture: ComponentFixture<SplitSelector>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SplitSelector],
+      providers: [provideZonelessChangeDetection()],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(SplitSelector);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/allocations/split-selector/split-selector.ts
+++ b/src/app/components/allocations/split-selector/split-selector.ts
@@ -1,0 +1,105 @@
+import {Component, signal, inject, input, effect} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {MatIcon} from '@angular/material/icon';
+import {Account} from 'ynab';
+
+import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
+import {AbsoluteSplitAllocation, AbsoluteSplitEntry, Allocation} from '../../../../lib/models/allocation';
+
+@Component({
+  selector: 'ya-split-selector',
+  templateUrl: './split-selector.html',
+  styleUrl: './split-selector.scss',
+  imports: [ReactiveFormsModule, MatIcon],
+})
+export class SplitSelector {
+  readonly allocation = input<Allocation | null>();
+
+  protected readonly splits = signal<ConfiguredSplit[]>([
+    // Start the user off with two blank splits
+    this.mkSplit(),
+    this.mkSplit(),
+  ]);
+
+  protected readonly ynabStorage = inject(YnabStorage);
+
+  constructor() {
+    effect(() => {
+      const allocation = this.allocation();
+      if (!allocation) return;
+
+      this.importFromAllocation(allocation);
+    });
+  }
+
+  getSplits(): FinalSplit[] {
+    const output: FinalSplit[] = [];
+    for (const split of this.splits()) {
+      const account = split.account.value;
+      const amount = split.amount.value ?? 0;
+      if (!account) continue;
+
+      output.push({account, amount});
+    }
+    return output;
+  }
+
+  getEntries(): AbsoluteSplitEntry[] {
+    return this.getSplits().map((s) => ({
+      accountId: s.account.id,
+      millisAmount: s.amount * 1000.0,
+    }));
+  }
+
+  protected removeSplit(event: Event, index: number) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const splits = this.splits();
+    const newSplits = [
+      ...splits.slice(0, index),
+      ...splits.slice(index + 1),
+    ];
+
+    this.splits.set(newSplits);
+  }
+
+  protected addSplit() {
+    this.splits.update((s) => [...s, this.mkSplit()]);
+  }
+
+  private mkSplit(): ConfiguredSplit {
+    return {
+      account: new FormControl<Account | null>(null),
+      amount: new FormControl<number>(0),
+    };
+  }
+
+  private importFromAllocation(allocation: Allocation | null) {
+    if (!allocation) return;
+    if (!(allocation instanceof AbsoluteSplitAllocation)) return;
+
+    const newSplits: ConfiguredSplit[] = [];
+    for (const split of allocation.splits) {
+      const account = this.ynabStorage.findAccount(split.accountId);
+      if (!account) continue;
+
+      newSplits.push({
+        account: new FormControl(account),
+        amount: new FormControl(split.millisAmount / 1000.0),
+      });
+    }
+
+    this.splits.set(newSplits);
+  }
+}
+
+interface ConfiguredSplit {
+  readonly account: FormControl<Account | null>;
+  readonly amount: FormControl<number | null>;
+}
+
+interface FinalSplit {
+  readonly account: Account;
+  readonly amount: number;
+}

--- a/src/app/components/common/dropdown-button/dropdown-button.html
+++ b/src/app/components/common/dropdown-button/dropdown-button.html
@@ -23,12 +23,21 @@
       <ul class="menu-items">
         @for (item of menuItems(); track item.value) {
           <li>
-            <button cdkMenuItem (click)="item.action(item.value)">
-              @if (item.icon) {
-                <mat-icon inline aria-hidden="true">{{ item.icon }}</mat-icon>
-              }
-              {{ item.label }}
-            </button>
+            @if (noClose()) {
+              <button (click)="item.action(item.value)">
+                @if (item.icon) {
+                  <mat-icon inline aria-hidden="true">{{ item.icon }}</mat-icon>
+                }
+                {{ item.label }}
+              </button>
+            } @else {
+              <button cdkMenuItem (click)="item.action(item.value)">
+                @if (item.icon) {
+                  <mat-icon inline aria-hidden="true">{{ item.icon }}</mat-icon>
+                }
+                {{ item.label }}
+              </button>
+            }
           </li>
         }
       </ul>

--- a/src/app/components/common/dropdown-button/dropdown-button.ts
+++ b/src/app/components/common/dropdown-button/dropdown-button.ts
@@ -1,4 +1,4 @@
-import {Component, signal, input, ViewChild} from '@angular/core';
+import {Component, signal, input, ViewChild, booleanAttribute} from '@angular/core';
 import {CdkMenuTrigger, CdkMenu, CdkMenuItem} from '@angular/cdk/menu';
 import {MatIcon} from '@angular/material/icon';
 
@@ -15,6 +15,7 @@ export class DropdownButton<MenuItemType> {
   readonly icon = input<string | null>(null);
   readonly flat = input<boolean>(false);
   readonly disabled = input<boolean>(false);
+  readonly noClose = input(false, {transform: booleanAttribute});
 
   protected readonly dropdownShowing = signal<boolean>(false);
 

--- a/src/lib/accounts/account_execution_result.spec.ts
+++ b/src/lib/accounts/account_execution_result.spec.ts
@@ -1,0 +1,102 @@
+import {Category} from "ynab";
+
+import {AccountExecutionBuilder, AccountExecutionResult} from "./account_execution_result";
+import {AbsoluteSplitAllocation, AbsoluteSplitEntry, SingleAllocation} from "../models/allocation";
+
+describe("AccountExecutionBuilder", () => {
+  it("sums up values correctly", () => {
+    const categories = [
+      cat("1", 1000),
+      cat("2", 2000),
+    ];
+    const allocations = [
+      single("1", "fake_account_1"),
+      absoluteSplit("2", [
+        {
+          accountId: "fake_account_1",
+          millisAmount: 1000,
+        },
+        {
+          accountId: "fake_account_2",
+          millisAmount: 1000,
+        },
+      ], "fake_account_3"),
+    ];
+    const results = new AccountExecutionBuilder(allocations, categories).build();
+
+    expect(results.size).toEqual(2);
+    assertAccount(results.get("fake_account_1")!, 2, 2000);
+    assertAccount(results.get("fake_account_2")!, 1, 1000);
+  });
+
+  it("overflows values to the default account, if needed", () => {
+    const categories = [
+      cat("1", 1000),
+      cat("2", 5000),
+    ];
+    const allocations = [
+      single("1", "fake_account_1"),
+      absoluteSplit("2", [
+        {
+          accountId: "fake_account_1",
+          millisAmount: 1000,
+        },
+        {
+          accountId: "fake_account_2",
+          millisAmount: 1000,
+        },
+      ], "fake_account_3"),
+    ];
+    const results = new AccountExecutionBuilder(allocations, categories).build();
+
+    expect(results.size).toEqual(3);
+    assertAccount(results.get("fake_account_1")!, 2, 2000);
+    assertAccount(results.get("fake_account_2")!, 1, 1000);
+    assertAccount(results.get("fake_account_3")!, 1, 3000);
+  });
+
+  it("overflows only the available amount", () => {
+    const categories = [
+      cat("1", 1000),
+      cat("2", 500),
+    ];
+    const allocations = [
+      single("1", "fake_account_1"),
+      absoluteSplit("2", [
+        {
+          accountId: "fake_account_1",
+          millisAmount: 1000,
+        },
+        {
+          accountId: "fake_account_2",
+          millisAmount: 1000,
+        },
+      ], "fake_account_3"),
+    ];
+    const results = new AccountExecutionBuilder(allocations, categories).build();
+
+    expect(results.size).toEqual(2);
+    assertAccount(results.get("fake_account_1")!, 2, 1500);
+    assertAccount(results.get("fake_account_2")!, 1, 0);
+  });
+});
+
+function assertAccount(result: AccountExecutionResult, categoryCount: number, millis: number) {
+  expect(result.categories.length).toEqual(categoryCount);
+  expect(result.allocatedMillis).toEqual(millis);
+}
+
+function cat(id: string, balance: number): Category {
+  return {
+    id,
+    balance,
+  } as Category;
+}
+
+function single(categoryId: string, accountId: string): SingleAllocation {
+  return new SingleAllocation("fake_budget", categoryId, accountId);
+}
+
+function absoluteSplit(categoryId: string, entries: AbsoluteSplitEntry[], defaultCategoryId: string): AbsoluteSplitAllocation {
+  return new AbsoluteSplitAllocation("fake_budget", categoryId, defaultCategoryId, entries);
+}

--- a/src/lib/accounts/account_execution_result.ts
+++ b/src/lib/accounts/account_execution_result.ts
@@ -28,7 +28,10 @@ export class AccountExecutionBuilder {
           runningBalance -= splitAmount;
           this.add(split.accountId, category, splitAmount);
         }
-        // TODO: Add fallback account logic here
+
+        if (runningBalance <= 0) continue;
+
+        this.add(allocation.defaultAccountId, category, runningBalance);
       } else {
         throw new Error("Unsupported allocation type.");
       }

--- a/src/lib/accounts/account_execution_result.ts
+++ b/src/lib/accounts/account_execution_result.ts
@@ -1,0 +1,66 @@
+import {Category} from "ynab";
+import {AbsoluteSplitAllocation, Allocation, SingleAllocation} from "../models/allocation";
+
+export class AccountExecutionBuilder {
+  private readonly accumulator = new Map<AccountId, AccountExecutionResultBuilder>();
+  private readonly categories = new Map<CategoryId, Category>();
+
+  constructor(
+    private readonly allocations: Allocation[],
+    categories: Category[],
+  ) {
+    for (const category of categories) {
+      this.categories.set(category.id, category);
+    }
+  }
+
+  build(): Map<AccountId, AccountExecutionResult> {
+    for (const allocation of this.allocations) {
+      const category = this.categories.get(allocation.categoryId) ?? null;
+      if (!category) continue;
+
+      if (allocation instanceof SingleAllocation) {
+        this.add(allocation.accountId, category, category.balance);
+      } else if (allocation instanceof AbsoluteSplitAllocation) {
+        let runningBalance = category.balance;
+        for (const split of allocation.splits) {
+          const splitAmount = runningBalance < split.millisAmount ? runningBalance : split.millisAmount;
+          runningBalance -= splitAmount;
+          this.add(split.accountId, category, splitAmount);
+        }
+        // TODO: Add fallback account logic here
+      } else {
+        throw new Error("Unsupported allocation type.");
+      }
+    }
+
+    return this.accumulator;
+  }
+
+  private add(accountId: AccountId, category: Category, millis: number) {
+    if (!this.accumulator.has(accountId)) {
+      this.accumulator.set(accountId, {
+        categories: [category],
+        allocatedMillis: millis,
+      });
+      return;
+    }
+
+    const builder = this.accumulator.get(accountId)!;
+    builder.categories.push(category);
+    builder.allocatedMillis += millis;
+  }
+}
+
+export interface AccountExecutionResultBuilder {
+  categories: Category[];
+  allocatedMillis: number;
+}
+
+export interface AccountExecutionResult {
+  readonly categories: Category[];
+  readonly allocatedMillis: number;
+}
+
+type AccountId = string;
+type CategoryId = string;

--- a/src/lib/models/allocation.spec.ts
+++ b/src/lib/models/allocation.spec.ts
@@ -1,14 +1,15 @@
-import {Allocation} from "./allocation";
+import {Allocation, AllocationType, SingleAllocation} from "./allocation";
 
-describe('Allocation', () => {
+describe('SingleAllocation', () => {
   describe('.toSchema()', () => {
     it('outputs equivalent schema', () => {
-      const alloc = new Allocation(
+      const alloc = new SingleAllocation(
           'fake_budget_id',
           'fake_category_id',
           'fake_account_id');
 
       expect(alloc.toSchema('fake_user_id')).toEqual({
+        type: AllocationType.SINGLE,
         userId: 'fake_user_id',
         budgetId: 'fake_budget_id',
         categoryId: 'fake_category_id',
@@ -20,11 +21,12 @@ describe('Allocation', () => {
   describe('.fromSchema()', () => {
     it('loads all data from the provided schema', () => {
       const alloc = Allocation.fromSchema({
+        type: AllocationType.SINGLE,
         userId: 'fake_user_id',
         budgetId: 'fake_budget_id',
         categoryId: 'fake_category_id',
         accountId: 'fake_account_id',
-      });
+      }) as SingleAllocation;
 
       expect(alloc.budgetId).toEqual('fake_budget_id');
       expect(alloc.categoryId).toEqual('fake_category_id');

--- a/src/lib/models/allocation.ts
+++ b/src/lib/models/allocation.ts
@@ -2,33 +2,123 @@
  * Represents a user-configured allocation of money in a particular budget
  * category into a financial account.
  */
-export class Allocation {
+export abstract class Allocation {
   constructor(
-    readonly budgetId: string,
-    readonly categoryId: string,
-    readonly accountId: string) {}
+      readonly budgetId: string,
+      readonly categoryId: string) {}
+
+  abstract toSchema(userId: string): AllocationSchema;
+
+  static fromSchema(schema: LegacyAllocationSchema): Allocation {
+    switch (schema.type) {
+      case undefined:
+      case AllocationType.SINGLE:
+        return new SingleAllocation(schema.budgetId, schema.categoryId, schema.accountId);
+      default:
+        return new UnknownAllocation(schema.budgetId, schema.categoryId);
+    }
+  }
+}
+
+/**
+ * An allocation of a single category to a single account.
+ */
+export class SingleAllocation extends Allocation {
+  constructor(
+      budgetId: string,
+      categoryId: string,
+      readonly accountId: string) {
+    super(budgetId, categoryId);
+  }
 
   /**
    * Returns a Firestore-friendly object that matches this allocation.
    * @param userId The ID of the user this Allocation is associated with.
    */
-  toSchema(userId: string): AllocationSchema {
+  override toSchema(userId: string): AllocationSchema {
     return {
       userId,
+      type: AllocationType.SINGLE,
       budgetId: this.budgetId,
       categoryId: this.categoryId,
       accountId: this.accountId,
     };
   }
+}
 
-  static fromSchema(schema: AllocationSchema): Allocation {
-    return new Allocation(schema.budgetId, schema.categoryId, schema.accountId);
+export class AbsoluteSplitAllocation extends Allocation {
+  constructor(
+      budgetId: string,
+      categoryId: string,
+      readonly splits: AbsoluteSplitEntry[]) {
+    super(budgetId, categoryId);
+  }
+
+  override toSchema(userId: string): AllocationSchema {
+    return {
+      type: AllocationType.ABSOLUTE_SPLIT,
+      userId,
+      budgetId: this.budgetId,
+      categoryId: this.categoryId,
+      splits: this.splits,
+    };
   }
 }
 
-export interface AllocationSchema {
+/**
+ * Represents an allocation from the database which had a type that was
+ * unrecognized.
+ */
+export class UnknownAllocation extends Allocation {
+  override toSchema(userId: string): AllocationSchema {
+    throw new Error('Cannot convert allocation to schema, it is unknown.');
+  }
+}
+
+export enum AllocationType {
+  // This allocation allocates a category to one account.
+  SINGLE = 'single',
+
+  // This allocation allocates a category to multiple accounts, wherein each
+  // account gets a fixed number which trickles down to a 'default' account.
+  ABSOLUTE_SPLIT = 'absolute_split',
+}
+
+/**
+ * The ideal, outgoing schema to Firestore.
+ */
+export type AllocationSchema = {
   readonly userId: string;
   readonly budgetId: string;
   readonly categoryId: string;
+} & (
+  {
+    readonly type: AllocationType.SINGLE;
+    readonly accountId: string;
+  } | {
+    readonly type: AllocationType.ABSOLUTE_SPLIT;
+    readonly splits: AbsoluteSplitEntry[];
+  }
+);
+
+/**
+ * The historical, possible-to-be-in Firestore schema.
+ */
+export type LegacyAllocationSchema = {
+  readonly userId: string;
+  readonly budgetId: string;
+  readonly categoryId: string;
+} & (
+  {
+    readonly type?: AllocationType.SINGLE;
+    readonly accountId: string;
+  } | {
+    readonly type: AllocationType.ABSOLUTE_SPLIT;
+    readonly splits: AbsoluteSplitEntry[];
+  }
+);
+
+export interface AbsoluteSplitEntry {
   readonly accountId: string;
+  readonly millisAmount: number;
 }

--- a/src/lib/models/allocation.ts
+++ b/src/lib/models/allocation.ts
@@ -14,8 +14,12 @@ export abstract class Allocation {
       case undefined:
       case AllocationType.SINGLE:
         return new SingleAllocation(schema.budgetId, schema.categoryId, schema.accountId);
-      default:
-        return new UnknownAllocation(schema.budgetId, schema.categoryId);
+      case AllocationType.ABSOLUTE_SPLIT:
+        return new AbsoluteSplitAllocation(
+            schema.budgetId,
+            schema.categoryId,
+            schema.defaultAccountId,
+            schema.splits);
     }
   }
 }
@@ -62,6 +66,7 @@ export class AbsoluteSplitAllocation extends Allocation {
       budgetId: this.budgetId,
       categoryId: this.categoryId,
       splits: this.splits,
+      defaultAccountId: this.defaultAccountId,
     };
   }
 }
@@ -99,6 +104,7 @@ export type AllocationSchema = {
   } | {
     readonly type: AllocationType.ABSOLUTE_SPLIT;
     readonly splits: AbsoluteSplitEntry[];
+    readonly defaultAccountId: string;
   }
 );
 
@@ -116,6 +122,7 @@ export type LegacyAllocationSchema = {
   } | {
     readonly type: AllocationType.ABSOLUTE_SPLIT;
     readonly splits: AbsoluteSplitEntry[];
+    readonly defaultAccountId: string;
   }
 );
 

--- a/src/lib/models/allocation.ts
+++ b/src/lib/models/allocation.ts
@@ -50,6 +50,7 @@ export class AbsoluteSplitAllocation extends Allocation {
   constructor(
       budgetId: string,
       categoryId: string,
+      readonly defaultAccountId: string,
       readonly splits: AbsoluteSplitEntry[]) {
     super(budgetId, categoryId);
   }

--- a/src/lib/ynab/ynab_storage.ts
+++ b/src/lib/ynab/ynab_storage.ts
@@ -1,5 +1,5 @@
 import {Injectable, signal, computed, resource, effect, inject, ResourceRef} from "@angular/core";
-import {AccountType, API, BudgetSummary, Category} from "ynab";
+import {Account, AccountType, API, BudgetSummary, Category} from "ynab";
 
 import {SettingsStorage} from "../firebase/settings_storage";
 import {getMonthsLabel, latestMonth, monthDistance, monthToApiMonth, parseMonth} from "../time/months";
@@ -119,6 +119,8 @@ export class YnabStorage {
           // money there.
           .filter((a) => a.type !== AccountType.CreditCard && a.type !== AccountType.LineOfCredit);
     },
+
+    defaultValue: [],
   });
 
   /**
@@ -234,6 +236,15 @@ export class YnabStorage {
         sessionStorage.removeItem('ynab.apiKey');
       }
     });
+  }
+
+  findAccount(accountId: string): Account | null {
+    const accounts = this.accounts.value();
+    for (const account of accounts) {
+      if (account.id === accountId) return account;
+    }
+
+    return null;
   }
 }
 

--- a/src/styles/_button.scss
+++ b/src/styles/_button.scss
@@ -1,4 +1,5 @@
-button.ya-button {
+button.ya-button,
+span.ya-button {
   --theme-color_: #eee;
   --theme-complement-color_: #000;
   --shadow-color_: color-mix(in srgb, var(--theme-color_) 70%, #000);
@@ -30,6 +31,7 @@ button.ya-button {
                 0 4px 0 var(--shadow-color_),
                 0 5px 0 var(--shadow-color_);
     transform: translateY(-2px);
+    cursor: pointer;
   }
 
   &:active {
@@ -46,7 +48,7 @@ button.ya-button {
     &:active {
       box-shadow: none;
       transform: translateY(3px);
-      opacity: 0.75;
+      opacity: 0.6;
     }
   }
 


### PR DESCRIPTION
Absolute splits allow for the user to set trickle-down allocations for multiple accounts.

Closes #39 