### PR TITLE
Add AccountMetadata model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ynab-allocation-manager",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ynab-allocation-manager",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "dependencies": {
         "@angular/cdk": "^20.0.3",
         "@angular/common": "^20.0.0",

--- a/src/lib/models/account_metadata.spec.ts
+++ b/src/lib/models/account_metadata.spec.ts
@@ -1,0 +1,43 @@
+import {
+  AccountMetadata,
+  AccountMetadataSchema,
+} from './account_metadata';
+
+describe('AccountMetadata', () => {
+  describe('.toSchema()', () => {
+    it('outputs equivalent schema', () => {
+      const accountMetadata = new AccountMetadata(
+        'fake_account_id',
+        0.05,
+        100000,
+        50000
+      );
+
+      expect(accountMetadata.toSchema('fake_user_id')).toEqual({
+        userId: 'fake_user_id',
+        accountId: 'fake_account_id',
+        interestRate: 0.05,
+        interestThresholdMillis: 100000,
+        minimumBalanceMillis: 50000,
+      });
+    });
+  });
+
+  describe('.fromSchema()', () => {
+    it('loads all data from the provided schema', () => {
+      const schema: AccountMetadataSchema = {
+        userId: 'fake_user_id',
+        accountId: 'fake_account_id',
+        interestRate: 0.05,
+        interestThresholdMillis: 100000,
+        minimumBalanceMillis: 50000,
+      };
+      const accountMetadata = AccountMetadata.fromSchema(schema);
+
+      expect(accountMetadata.accountId).toEqual('fake_account_id');
+      expect(accountMetadata.interestRate).toEqual(0.05);
+      expect(accountMetadata.interestThresholdMillis).toEqual(100000);
+      expect(accountMetadata.minimumBalanceMillis).toEqual(50000);
+    });
+  });
+});

--- a/src/lib/models/account_metadata.ts
+++ b/src/lib/models/account_metadata.ts
@@ -1,0 +1,42 @@
+/**
+ * Represents metadata about a single bank account.
+ */
+export class AccountMetadata {
+  constructor(
+    readonly accountId: string,
+    readonly interestRate: number,
+    readonly interestThresholdMillis: number,
+    readonly minimumBalanceMillis: number
+  ) {}
+
+  /**
+   * Returns a Firestore-friendly object that matches this allocation.
+   * @param userId The ID of the user this Allocation is associated with.
+   */
+  toSchema(userId: string): AccountMetadataSchema {
+    return {
+      userId,
+      accountId: this.accountId,
+      interestRate: this.interestRate,
+      interestThresholdMillis: this.interestThresholdMillis,
+      minimumBalanceMillis: this.minimumBalanceMillis,
+    };
+  }
+
+  static fromSchema(schema: AccountMetadataSchema): AccountMetadata {
+    return new AccountMetadata(
+      schema.accountId,
+      schema.interestRate,
+      schema.interestThresholdMillis,
+      schema.minimumBalanceMillis
+    );
+  }
+}
+
+export interface AccountMetadataSchema {
+  readonly userId: string;
+  readonly accountId: string;
+  readonly interestRate: number;
+  readonly interestThresholdMillis: number;
+  readonly minimumBalanceMillis: number;
+}


### PR DESCRIPTION
This commit introduces the new `AccountMetadata` model, which maps the ID of a YNAB account to various attributes about a bank account.

The model includes the following attributes:
- `accountId`: The ID of the account.
- `interestRate`: The APY associated with the account.
- `interestThresholdMillis`: The threshold over which the interest rate applies.
- `minimumBalanceMillis`: The minimum balance required to not incur fees.

The commit also includes unit tests for the new model.