### PR TITLE
Add metadata dialog for accounts

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -6,6 +6,10 @@ service cloud.firestore {
       allow read, write, delete: if request.auth != null && request.auth.uid == resource.data.userId;
       allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
     }
+    match /accounts/{accountId} {
+      allow read, write, delete: if request.auth != null && request.auth.uid == resource.data.userId;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.userId;
+    }
     match /users/{userId} {
       allow read, write, delete, create: if request.auth != null && request.auth.uid == userId;
     }

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
@@ -1,0 +1,5 @@
+<h2 mat-dialog-title>{{ data.account.name }}</h2>
+
+<mat-dialog-content>
+  Something coming soon.
+</mat-dialog-content>

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
@@ -34,5 +34,24 @@
         The minimum balance required in this account to not accrue fees.
       </p>
     </div>
+
+    <div class="spacer"></div>
+    <div class="spacer"></div>
+
+    <div class="form-item">
+      <span>&nbsp;</span>
+      <label>Last reconciled on YNAB</label>
+      <ya-reconciled-time [time]="data.account.last_reconciled_at" />
+      <span>&nbsp;</span>
+    </div>
+
+    <div class="spacer"></div>
+
+    <div class="form-item">
+      <span>&nbsp;</span>
+      <label>Last reconciled</label>
+      <ya-reconciled-time [time]="null" />
+      <span>&nbsp;</span>
+    </div>
   </div>
 </mat-dialog-content>

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
@@ -5,7 +5,7 @@
     <div class="form-item">
       <mat-icon inline aria-hidden="true">percent</mat-icon>
       <label>Interest rate</label>
-      <input class="ya-input" />
+      <input class="ya-input" [formControl]="interestRateControl" />
       <span>%</span>
       <p class="info">
         The APY interest rate on this account. This will be shown in the
@@ -17,7 +17,7 @@
     <div class="form-item">
       <mat-icon inline aria-hidden="true">vertical_align_top</mat-icon>
       <label>Interest rate threshold</label>
-      <input class="ya-input" />
+      <input class="ya-input" [formControl]="interestThresholdControl" />
       <span>&nbsp;</span>
       <p class="info">
         The minimum account balanced required to get this account's advertised
@@ -28,7 +28,7 @@
     <div class="form-item">
       <mat-icon inline aria-hidden="true">running_with_errors</mat-icon>
       <label>Minimum balance</label>
-      <input class="ya-input" />
+      <input class="ya-input" [formControl]="minimumBalanceControl" />
       <span>&nbsp;</span>
       <p class="info">
         The minimum balance required in this account to not accrue fees.
@@ -55,3 +55,15 @@
     </div>
   </div>
 </mat-dialog-content>
+
+<mat-dialog-actions>
+  <button class="ya-button flat" (click)="closeDialog()">
+    <mat-icon inline aria-hidden="true">close</mat-icon>
+    Cancel
+  </button>
+
+  <button class="ya-button flat site-theme" (click)="save()">
+    <mat-icon inline aria-hidden="true">save</mat-icon>
+    Save
+  </button>
+</mat-dialog-actions>

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
@@ -1,5 +1,38 @@
 <h2 mat-dialog-title>{{ data.account.name }}</h2>
 
 <mat-dialog-content>
-  Something coming soon.
+  <div class="form">
+    <div class="form-item">
+      <mat-icon inline aria-hidden="true">percent</mat-icon>
+      <label>Interest rate</label>
+      <input class="ya-input" />
+      <span>%</span>
+      <p class="info">
+        The APY interest rate on this account. This will be shown in the
+        accounts list to help indicate which accounts are more optimal for
+        storing cash.
+      </p>
+    </div>
+
+    <div class="form-item">
+      <mat-icon inline aria-hidden="true">vertical_align_top</mat-icon>
+      <label>Interest rate threshold</label>
+      <input class="ya-input" />
+      <span>&nbsp;</span>
+      <p class="info">
+        The minimum account balanced required to get this account's advertised
+        interest rate.
+      </p>
+    </div>
+
+    <div class="form-item">
+      <mat-icon inline aria-hidden="true">running_with_errors</mat-icon>
+      <label>Minimum balance</label>
+      <input class="ya-input" />
+      <span>&nbsp;</span>
+      <p class="info">
+        The minimum balance required in this account to not accrue fees.
+      </p>
+    </div>
+  </div>
 </mat-dialog-content>

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.scss
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.scss
@@ -7,6 +7,11 @@
   grid-template-columns: min-content 1fr min-content;
   align-items: center;
   gap: 4px 12px;
+
+  .spacer {
+    grid-column: 1 / 5;
+    height: 4px;
+  }
 }
 
 .form-item {

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.scss
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  background: #fff;
+}

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.scss
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.scss
@@ -1,4 +1,38 @@
 :host {
   display: block;
-  background: #fff;
+}
+
+.form {
+  display: grid;
+  grid-template-columns: min-content 1fr min-content;
+  align-items: center;
+  gap: 4px 12px;
+}
+
+.form-item {
+  display: contents;
+
+  > label,
+  > span {
+    white-space: nowrap;
+  }
+
+  > mat-icon {
+    font-size: 20px;
+  }
+
+  > label {
+    font-weight: bold;
+    font-size: 18px;
+  }
+
+  .ya-input {
+    text-align: right;
+  }
+
+  .info {
+    grid-column: 2 / 5;
+    margin: 0 0 10px;
+    font-size: 14px;
+  }
 }

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.spec.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.spec.ts
@@ -1,0 +1,25 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {AccountMetadataDialog} from './account-metadata-dialog';
+import {provideZonelessChangeDetection} from '@angular/core';
+
+describe('AccountMetadataDialog', () => {
+  let component: AccountMetadataDialog;
+  let fixture: ComponentFixture<AccountMetadataDialog>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AccountMetadataDialog],
+      providers: [provideZonelessChangeDetection()],
+    })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AccountMetadataDialog);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.spec.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.spec.ts
@@ -1,25 +1,20 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {provideZonelessChangeDetection} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {MatTestDialogOpenerModule, MatTestDialogOpener} from '@angular/material/dialog/testing';
 
 import {AccountMetadataDialog} from './account-metadata-dialog';
-import {provideZonelessChangeDetection} from '@angular/core';
 
 describe('AccountMetadataDialog', () => {
-  let component: AccountMetadataDialog;
-  let fixture: ComponentFixture<AccountMetadataDialog>;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AccountMetadataDialog],
-      providers: [provideZonelessChangeDetection()],
-    })
-      .compileComponents();
-
-    fixture = TestBed.createComponent(AccountMetadataDialog);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
+      imports: [AccountMetadataDialog, MatTestDialogOpenerModule],
+      providers: [
+        provideZonelessChangeDetection(),
+      ],
+    }).compileComponents();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    MatTestDialogOpener.withComponent(AccountMetadataDialog);
   });
 });

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
@@ -6,6 +6,7 @@ import {MatIcon} from '@angular/material/icon';
 
 import {AccountMetadata} from '../../../../lib/models/account_metadata';
 import {FirestoreStorage} from '../../../../lib/firestore/firestore_storage';
+import {ReconciledTime} from '../../time/reconciled-time/reconciled-time';
 import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
 
 /**
@@ -15,7 +16,13 @@ import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
   selector: 'ya-account-metadata-dialog',
   templateUrl: './account-metadata-dialog.html',
   styleUrl: './account-metadata-dialog.scss',
-  imports: [ReactiveFormsModule, MatDialogContent, MatDialogTitle, MatIcon],
+  imports: [
+    MatDialogContent,
+    MatDialogTitle,
+    MatIcon,
+    ReactiveFormsModule,
+    ReconciledTime,
+  ],
 })
 export class AccountMetadataDialog implements OnInit {
   protected readonly interestRateControl = new FormControl<number>(0);

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
@@ -1,7 +1,8 @@
 import {Account} from 'ynab';
-import {Component, inject, OnInit} from '@angular/core';
+import {Component, inject, OnInit, HostBinding} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MatIcon} from '@angular/material/icon';
 
 import {AccountMetadata} from '../../../../lib/models/account_metadata';
 import {FirestoreStorage} from '../../../../lib/firestore/firestore_storage';
@@ -14,7 +15,7 @@ import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
   selector: 'ya-account-metadata-dialog',
   templateUrl: './account-metadata-dialog.html',
   styleUrl: './account-metadata-dialog.scss',
-  imports: [ReactiveFormsModule, MatDialogContent, MatDialogTitle],
+  imports: [ReactiveFormsModule, MatDialogContent, MatDialogTitle, MatIcon],
 })
 export class AccountMetadataDialog implements OnInit {
   protected readonly interestRateControl = new FormControl<number>(0);
@@ -25,6 +26,11 @@ export class AccountMetadataDialog implements OnInit {
   private readonly firestoreStorage = inject(FirestoreStorage);
   private readonly ynabStorage = inject(YnabStorage);
   private readonly dialogRef = inject(MatDialogRef<AccountMetadataDialog>);
+
+  @HostBinding('class')
+  get dialogClass(): string {
+    return 'ya-dialog';
+  }
 
   ngOnInit() {
     // Populate values from the provided AccountMetadata instance, if it exists.

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
@@ -1,0 +1,69 @@
+import {Account} from 'ynab';
+import {Component, inject, OnInit} from '@angular/core';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+import {MAT_DIALOG_DATA, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+
+import {AccountMetadata} from '../../../../lib/models/account_metadata';
+import {FirestoreStorage} from '../../../../lib/firestore/firestore_storage';
+import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
+
+/**
+ * Renders a dialog that lets the user edit metadata related to their accounts.
+ */
+@Component({
+  selector: 'ya-account-metadata-dialog',
+  templateUrl: './account-metadata-dialog.html',
+  styleUrl: './account-metadata-dialog.scss',
+  imports: [ReactiveFormsModule, MatDialogContent, MatDialogTitle],
+})
+export class AccountMetadataDialog implements OnInit {
+  protected readonly interestRateControl = new FormControl<number>(0);
+  protected readonly interestThresholdControl = new FormControl<number>(0);
+  protected readonly minimumBalanceControl = new FormControl<number>(0);
+  protected readonly data = inject<DialogData>(MAT_DIALOG_DATA);
+
+  private readonly firestoreStorage = inject(FirestoreStorage);
+  private readonly ynabStorage = inject(YnabStorage);
+  private readonly dialogRef = inject(MatDialogRef<AccountMetadataDialog>);
+
+  ngOnInit() {
+    // Populate values from the provided AccountMetadata instance, if it exists.
+    if (this.data.metadata) {
+      this.interestRateControl.setValue(this.data.metadata.interestRate * 100.0);
+      this.interestThresholdControl.setValue(this.data.metadata.interestThresholdMillis * 1000.0);
+      this.minimumBalanceControl.setValue(this.data.metadata.minimumBalanceMillis * 1000.0);
+    }
+  }
+
+  protected async save() {
+    const currentBudget = this.ynabStorage.selectedBudget();
+    if (!currentBudget) return;
+
+    const newInterestRate = this.interestRateControl.value ?? 0;
+    const newInterestThreshold = toMillis(this.interestThresholdControl.value);
+    const newMinimumBalance = toMillis(this.minimumBalanceControl.value);
+
+    const newMetadata = new AccountMetadata(
+        this.data.account.id,
+        currentBudget.id,
+        newInterestRate,
+        newInterestThreshold,
+        newMinimumBalance);
+
+    await this.firestoreStorage.upsertAccount(newMetadata);
+  }
+
+  closeDialog(): void {
+    this.dialogRef.close();
+  }
+}
+
+function toMillis(val: number | null): number {
+  if (val === null) return 0;
+  return val * 1000;
+}
+
+interface DialogData {
+  readonly metadata: AccountMetadata | null;
+  readonly account: Account;
+}

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
@@ -1,7 +1,7 @@
 import {Account} from 'ynab';
 import {Component, inject, OnInit, HostBinding} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
-import {MAT_DIALOG_DATA, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
+import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatIcon} from '@angular/material/icon';
 
 import {AccountMetadata} from '../../../../lib/models/account_metadata';
@@ -17,6 +17,7 @@ import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
   templateUrl: './account-metadata-dialog.html',
   styleUrl: './account-metadata-dialog.scss',
   imports: [
+    MatDialogActions,
     MatDialogContent,
     MatDialogTitle,
     MatIcon,
@@ -43,8 +44,8 @@ export class AccountMetadataDialog implements OnInit {
     // Populate values from the provided AccountMetadata instance, if it exists.
     if (this.data.metadata) {
       this.interestRateControl.setValue(this.data.metadata.interestRate * 100.0);
-      this.interestThresholdControl.setValue(this.data.metadata.interestThresholdMillis * 1000.0);
-      this.minimumBalanceControl.setValue(this.data.metadata.minimumBalanceMillis * 1000.0);
+      this.interestThresholdControl.setValue(this.data.metadata.interestThresholdMillis / 1000.0);
+      this.minimumBalanceControl.setValue(this.data.metadata.minimumBalanceMillis / 1000.0);
     }
   }
 
@@ -59,14 +60,15 @@ export class AccountMetadataDialog implements OnInit {
     const newMetadata = new AccountMetadata(
         this.data.account.id,
         currentBudget.id,
-        newInterestRate,
+        newInterestRate === 0 ? newInterestRate : (newInterestRate / 100.0),
         newInterestThreshold,
         newMinimumBalance);
 
     await this.firestoreStorage.upsertAccount(newMetadata);
+    this.closeDialog();
   }
 
-  closeDialog(): void {
+  protected closeDialog(): void {
     this.dialogRef.close();
   }
 }

--- a/src/app/components/accounts/account-summary/account-summary.html
+++ b/src/app/components/accounts/account-summary/account-summary.html
@@ -1,6 +1,6 @@
-<div class="account-name">
+<button class="account-name" (click)="showMetadataDialog()">
   {{ account().account.name }}
-</div>
+</button>
 
 <div class="last-reconciled">
   @let lastReconciled = lastReconciledAt();

--- a/src/app/components/accounts/account-summary/account-summary.html
+++ b/src/app/components/accounts/account-summary/account-summary.html
@@ -3,12 +3,7 @@
 </button>
 
 <div class="last-reconciled">
-  @let lastReconciled = lastReconciledAt();
-  @if (lastReconciled) {
-    <ya-relative-time [date]="lastReconciled" />
-  } @else {
-    -
-  }
+  <ya-reconciled-time [time]="account().account.last_reconciled_at" />
 
   @if (lastReconciledWarning()) {
     <ya-dropdown-button dropdownLabel="Last reconciled awhile ago"

--- a/src/app/components/accounts/account-summary/account-summary.scss
+++ b/src/app/components/accounts/account-summary/account-summary.scss
@@ -3,12 +3,23 @@
 }
 
 .account-name {
+  display: block;
   font-weight: bold;
   margin: 0 0 6px;
   font-size: 16px;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
+  background: transparent;
+  color: #000;
+  border: none;
+  padding: 0;
+  text-align: left;
+  transition: color 200ms ease;
+
+  &:hover {
+    color: var(--theme-primary-color);
+  }
 }
 
 .last-reconciled {

--- a/src/app/components/accounts/account-summary/account-summary.ts
+++ b/src/app/components/accounts/account-summary/account-summary.ts
@@ -2,11 +2,11 @@ import {Component, input, computed, inject} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 
 import {AccountAllocation} from '../../../../lib/accounts/account_data';
+import {AccountMetadataDialog} from '../account-metadata-dialog/account-metadata-dialog';
 import {CurrencyCopyButton} from '../../common/currency-copy-button/currency-copy-button';
 import {Currency} from '../../common/currency/currency';
 import {DropdownButton, ButtonTheme} from '../../common/dropdown-button/dropdown-button';
-import {RelativeTime} from '../../time/relative-time/relative-time';
-import {AccountMetadataDialog} from '../account-metadata-dialog/account-metadata-dialog';
+import {ReconciledTime} from "../../time/reconciled-time/reconciled-time";
 
 @Component({
   selector: 'ya-account-summary',
@@ -16,7 +16,7 @@ import {AccountMetadataDialog} from '../account-metadata-dialog/account-metadata
     Currency,
     CurrencyCopyButton,
     DropdownButton,
-    RelativeTime,
+    ReconciledTime,
   ],
 })
 export class AccountSummary {

--- a/src/app/components/accounts/account-summary/account-summary.ts
+++ b/src/app/components/accounts/account-summary/account-summary.ts
@@ -1,11 +1,12 @@
 import {Component, input, computed, inject} from '@angular/core';
+import {MatDialog} from '@angular/material/dialog';
 
 import {AccountAllocation} from '../../../../lib/accounts/account_data';
 import {CurrencyCopyButton} from '../../common/currency-copy-button/currency-copy-button';
 import {Currency} from '../../common/currency/currency';
 import {DropdownButton, ButtonTheme} from '../../common/dropdown-button/dropdown-button';
 import {RelativeTime} from '../../time/relative-time/relative-time';
-import {YnabStorage} from '../../../../lib/ynab/ynab_storage';
+import {AccountMetadataDialog} from '../account-metadata-dialog/account-metadata-dialog';
 
 @Component({
   selector: 'ya-account-summary',
@@ -60,5 +61,14 @@ export class AccountSummary {
     }
   });
 
-  private readonly ynabStorage = inject(YnabStorage);
+  private readonly matDialog = inject(MatDialog);
+
+  protected showMetadataDialog() {
+    this.matDialog.open(AccountMetadataDialog, {
+      data: {
+        metadata: this.account().metadata,
+        account: this.account().account,
+      },
+    });
+  }
 }

--- a/src/app/components/time/reconciled-time/reconciled-time.html
+++ b/src/app/components/time/reconciled-time/reconciled-time.html
@@ -1,0 +1,6 @@
+@let reconDate = date();
+@if (reconDate !== null) {
+  <ya-relative-time [date]="reconDate" />
+} @else {
+  <span>-</span>
+}

--- a/src/app/components/time/reconciled-time/reconciled-time.scss
+++ b/src/app/components/time/reconciled-time/reconciled-time.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/src/app/components/time/reconciled-time/reconciled-time.spec.ts
+++ b/src/app/components/time/reconciled-time/reconciled-time.spec.ts
@@ -1,0 +1,24 @@
+import {provideZonelessChangeDetection} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {ReconciledTime} from './reconciled-time';
+
+describe('ReconciledTime', () => {
+  let component: ReconciledTime;
+  let fixture: ComponentFixture<ReconciledTime>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReconciledTime],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReconciledTime);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/time/reconciled-time/reconciled-time.spec.ts
+++ b/src/app/components/time/reconciled-time/reconciled-time.spec.ts
@@ -14,6 +14,7 @@ describe('ReconciledTime', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(ReconciledTime);
+    fixture.componentRef.setInput('time', null);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/components/time/reconciled-time/reconciled-time.ts
+++ b/src/app/components/time/reconciled-time/reconciled-time.ts
@@ -1,0 +1,19 @@
+import {Component, input, computed} from '@angular/core';
+import {RelativeTime} from '../relative-time/relative-time';
+
+@Component({
+  selector: 'ya-reconciled-time',
+  templateUrl: './reconciled-time.html',
+  styleUrl: './reconciled-time.scss',
+  imports: [RelativeTime],
+})
+export class ReconciledTime {
+  readonly time = input.required<string | null | undefined>();
+
+  protected readonly date = computed<Date | null>(() => {
+    const time = this.time();
+    if (!time) return null;
+
+    return new Date(time);
+  });
+}

--- a/src/lib/accounts/account_data.ts
+++ b/src/lib/accounts/account_data.ts
@@ -3,8 +3,8 @@ import {Account, Category} from "ynab";
 
 import {YnabStorage} from "../ynab/ynab_storage";
 import {FirestoreStorage} from "../firestore/firestore_storage";
-import {Allocation} from "../models/allocation";
 import {AccountExecutionBuilder} from "./account_execution_result";
+import {AccountMetadata} from "../models/account_metadata";
 
 /**
  * Contains pre-computed signals for common account information.
@@ -17,6 +17,7 @@ export class AccountData {
    */
   readonly accounts = computed<AccountAllocation[]>(() => {
     const accounts = this.ynabStorage.accounts.value() ?? [];
+    const metadata = this.firestoreStorage.accountMetadata();
     if (accounts.length < 1) return [];
 
     const groups = this.ynabStorage.latestCategories.value() ?? [];
@@ -27,9 +28,11 @@ export class AccountData {
 
     return accounts.map((account) => {
       const executionResult = executionResults.get(account.id) ?? null;
+      const accountMetadata = metadata.get(account.id) ?? null;
 
       return {
         account,
+        metadata: accountMetadata,
         categories: executionResult?.categories ?? [],
         total: executionResult?.allocatedMillis ?? 0,
       };
@@ -84,9 +87,7 @@ export class AccountData {
  */
 export interface AccountAllocation {
   readonly account: Account;
+  readonly metadata: AccountMetadata | null;
   readonly categories: Category[];
   readonly total: number;
 }
-
-type AccountId = string;
-type CategoryId = string;

--- a/src/lib/models/account_metadata.spec.ts
+++ b/src/lib/models/account_metadata.spec.ts
@@ -8,6 +8,7 @@ describe('AccountMetadata', () => {
     it('outputs equivalent schema', () => {
       const accountMetadata = new AccountMetadata(
         'fake_account_id',
+        'fake_budget_id',
         0.05,
         100000,
         50000
@@ -16,6 +17,7 @@ describe('AccountMetadata', () => {
       expect(accountMetadata.toSchema('fake_user_id')).toEqual({
         userId: 'fake_user_id',
         accountId: 'fake_account_id',
+        budgetId: 'fake_budget_id',
         interestRate: 0.05,
         interestThresholdMillis: 100000,
         minimumBalanceMillis: 50000,
@@ -28,6 +30,7 @@ describe('AccountMetadata', () => {
       const schema: AccountMetadataSchema = {
         userId: 'fake_user_id',
         accountId: 'fake_account_id',
+        budgetId: 'fake_budget_id',
         interestRate: 0.05,
         interestThresholdMillis: 100000,
         minimumBalanceMillis: 50000,
@@ -35,6 +38,7 @@ describe('AccountMetadata', () => {
       const accountMetadata = AccountMetadata.fromSchema(schema);
 
       expect(accountMetadata.accountId).toEqual('fake_account_id');
+      expect(accountMetadata.budgetId).toEqual('fake_budget_id');
       expect(accountMetadata.interestRate).toEqual(0.05);
       expect(accountMetadata.interestThresholdMillis).toEqual(100000);
       expect(accountMetadata.minimumBalanceMillis).toEqual(50000);

--- a/src/lib/models/account_metadata.ts
+++ b/src/lib/models/account_metadata.ts
@@ -4,6 +4,7 @@
 export class AccountMetadata {
   constructor(
     readonly accountId: string,
+    readonly budgetId: string,
     readonly interestRate: number,
     readonly interestThresholdMillis: number,
     readonly minimumBalanceMillis: number
@@ -17,6 +18,7 @@ export class AccountMetadata {
     return {
       userId,
       accountId: this.accountId,
+      budgetId: this.budgetId,
       interestRate: this.interestRate,
       interestThresholdMillis: this.interestThresholdMillis,
       minimumBalanceMillis: this.minimumBalanceMillis,
@@ -26,6 +28,7 @@ export class AccountMetadata {
   static fromSchema(schema: AccountMetadataSchema): AccountMetadata {
     return new AccountMetadata(
       schema.accountId,
+      schema.budgetId,
       schema.interestRate,
       schema.interestThresholdMillis,
       schema.minimumBalanceMillis
@@ -36,6 +39,7 @@ export class AccountMetadata {
 export interface AccountMetadataSchema {
   readonly userId: string;
   readonly accountId: string;
+  readonly budgetId: string;
   readonly interestRate: number;
   readonly interestThresholdMillis: number;
   readonly minimumBalanceMillis: number;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -45,4 +45,5 @@ button:hover {
 
 @import "styles/button";
 @import "styles/card";
+@import "styles/dialog";
 @import "styles/input";

--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -1,0 +1,13 @@
+.mat-mdc-dialog-container {
+  .ya-dialog {
+    .mat-mdc-dialog-title,
+    .mat-mdc-dialog-content {
+      font-family: var(--body-font);
+    }
+
+    .mat-mdc-dialog-title {
+      margin: 0 0 20px;
+      text-align: center;
+    }
+  }
+}

--- a/src/styles/_dialog.scss
+++ b/src/styles/_dialog.scss
@@ -9,5 +9,11 @@
       margin: 0 0 20px;
       text-align: center;
     }
+
+    .mat-mdc-dialog-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
   }
 }

--- a/src/styles/_input.scss
+++ b/src/styles/_input.scss
@@ -1,5 +1,5 @@
 input.ya-input {
-  padding: 4px 8px;
+  padding: 4px 12px;
   border: 1px solid #000;
   border-radius: 100px;
 }


### PR DESCRIPTION
This new dialog allows the user to input metadata about their accounts (like interest rate or minimum balance) to get more tailored warnings / suggestions for where to allocate their money.

This implements all of the metadata saving / loading / dialog end-to-end, but doesn't actually use that data for anything (yet).