### PR TITLE
Fix metadata reconciliation bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ynab-allocation-manager",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ynab-allocation-manager",
-      "version": "0.12.0",
+      "version": "0.13.1",
       "dependencies": {
         "@angular/cdk": "^20.0.3",
         "@angular/common": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-allocation-manager",
-  "version": "0.12.0",
+  "version": "0.13.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
@@ -63,7 +63,7 @@ export class AccountMetadataDialog implements OnInit {
         newInterestRate === 0 ? newInterestRate : (newInterestRate / 100.0),
         newInterestThreshold,
         newMinimumBalance,
-        this.data.metadata?.lastReconciled ?? null,
+        new Date(),
     );
 
     await this.firestoreStorage.upsertAccount(newMetadata);


### PR DESCRIPTION
Fixes a bug in how reconciling account metadata works wherein reconciling never updates the reconciled date. I think this code is an artifact of an older implementation.