### PR TITLE
Polish new account metadata feature

### DIFF
--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.html
@@ -2,28 +2,30 @@
 
 <mat-dialog-content>
   <div class="form">
-    <div class="form-item">
-      <mat-icon inline aria-hidden="true">percent</mat-icon>
-      <label>Interest rate</label>
-      <input class="ya-input" [formControl]="interestRateControl" />
-      <span>%</span>
-      <p class="info">
-        The APY interest rate on this account. This will be shown in the
-        accounts list to help indicate which accounts are more optimal for
-        storing cash.
-      </p>
-    </div>
+    @if (!isCheckingAccount()) {
+      <div class="form-item">
+        <mat-icon inline aria-hidden="true">percent</mat-icon>
+        <label>Interest rate</label>
+        <input class="ya-input" [formControl]="interestRateControl" />
+        <span>%</span>
+        <p class="info">
+          The APY interest rate on this account. This will be shown in the
+          accounts list to help indicate which accounts are more optimal for
+          storing cash.
+        </p>
+      </div>
 
-    <div class="form-item">
-      <mat-icon inline aria-hidden="true">vertical_align_top</mat-icon>
-      <label>Interest rate threshold</label>
-      <input class="ya-input" [formControl]="interestThresholdControl" />
-      <span>&nbsp;</span>
-      <p class="info">
-        The minimum account balanced required to get this account's advertised
-        interest rate.
-      </p>
-    </div>
+      <div class="form-item">
+        <mat-icon inline aria-hidden="true">vertical_align_top</mat-icon>
+        <label>Interest rate threshold</label>
+        <input class="ya-input" [formControl]="interestThresholdControl" />
+        <span>&nbsp;</span>
+        <p class="info">
+          The minimum account balanced required to get this account's advertised
+          interest rate.
+        </p>
+      </div>
+    }
 
     <div class="form-item">
       <mat-icon inline aria-hidden="true">running_with_errors</mat-icon>

--- a/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
+++ b/src/app/components/accounts/account-metadata-dialog/account-metadata-dialog.ts
@@ -1,5 +1,5 @@
-import {Account} from 'ynab';
-import {Component, inject, OnInit, HostBinding} from '@angular/core';
+import {Account, AccountType} from 'ynab';
+import {Component, inject, OnInit, HostBinding, signal} from '@angular/core';
 import {FormControl, ReactiveFormsModule} from '@angular/forms';
 import {MAT_DIALOG_DATA, MatDialogActions, MatDialogContent, MatDialogRef, MatDialogTitle} from '@angular/material/dialog';
 import {MatIcon} from '@angular/material/icon';
@@ -30,6 +30,7 @@ export class AccountMetadataDialog implements OnInit {
   protected readonly interestThresholdControl = new FormControl<number>(0);
   protected readonly minimumBalanceControl = new FormControl<number>(0);
   protected readonly data = inject<DialogData>(MAT_DIALOG_DATA);
+  protected readonly isCheckingAccount = signal<boolean>(false);
 
   private readonly firestoreStorage = inject(FirestoreStorage);
   private readonly ynabStorage = inject(YnabStorage);
@@ -47,6 +48,8 @@ export class AccountMetadataDialog implements OnInit {
       this.interestThresholdControl.setValue(this.data.metadata.interestThresholdMillis / 1000.0);
       this.minimumBalanceControl.setValue(this.data.metadata.minimumBalanceMillis / 1000.0);
     }
+
+    this.isCheckingAccount.set(this.data.account.type === AccountType.Checking);
   }
 
   protected async save() {

--- a/src/app/components/accounts/account-status-indicator/account-status-indicator.ts
+++ b/src/app/components/accounts/account-status-indicator/account-status-indicator.ts
@@ -5,6 +5,7 @@ import {Currency} from '../../common/currency/currency';
 import {AccountAllocation} from '../../../../lib/accounts/account_data';
 import {DropdownButton} from '../../common/dropdown-button/dropdown-button';
 import {ReconciledTime} from '../../time/reconciled-time/reconciled-time';
+import { AccountType } from 'ynab';
 
 @Component({
   selector: 'ya-account-status-indicator',
@@ -35,6 +36,8 @@ export class AccountStatusIndicator {
   });
 
   protected readonly metadataReconIsOutdated = computed<boolean>(() => {
+    if (this.isCashAccount()) return false;
+
     const lastRecon = this.account().metadata?.lastReconciled ?? null;
     if (lastRecon == null) return true;
 
@@ -42,6 +45,8 @@ export class AccountStatusIndicator {
   });
 
   protected readonly amountBelowMinimum = computed<number | null>(() => {
+    if (this.isCashAccount()) return null;
+
     const metadata = this.account().metadata;
     if (!metadata) return null;
     if (metadata.minimumBalanceMillis <= 0) return null;
@@ -50,6 +55,10 @@ export class AccountStatusIndicator {
     if (balance >= metadata.minimumBalanceMillis) return null;
 
     return metadata.minimumBalanceMillis - balance;
+  });
+
+  private readonly isCashAccount = computed<boolean>(() => {
+    return this.account().account.type === AccountType.Cash;
   });
 }
 

--- a/src/app/components/accounts/account-summary/account-summary.html
+++ b/src/app/components/accounts/account-summary/account-summary.html
@@ -1,4 +1,4 @@
-<button class="account-name" (click)="showMetadataDialog()">
+<button class="account-name" [class.no-click]="!allowMetadata()" (click)="showMetadataDialog()">
   {{ account().account.name }}
 </button>
 

--- a/src/app/components/accounts/account-summary/account-summary.scss
+++ b/src/app/components/accounts/account-summary/account-summary.scss
@@ -17,8 +17,12 @@
   text-align: left;
   transition: color 200ms ease;
 
-  &:hover {
+  &:not(.no-click):hover {
     color: var(--theme-primary-color);
+  }
+
+  &.no-click {
+    cursor: initial;
   }
 }
 

--- a/src/app/components/accounts/account-summary/account-summary.ts
+++ b/src/app/components/accounts/account-summary/account-summary.ts
@@ -1,3 +1,4 @@
+import {AccountType} from 'ynab';
 import {Component, input, computed, inject, booleanAttribute} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 
@@ -48,9 +49,19 @@ export class AccountSummary {
     }
   });
 
+  /**
+   * Only allow the user to edit metadata if the account isn't a cash account.
+   * A cash account definitionally shouldn't have metadata.
+   */
+  protected readonly allowMetadata = computed<boolean>(() => {
+    return this.account().account.type !== AccountType.Cash;
+  });
+
   private readonly matDialog = inject(MatDialog);
 
   protected showMetadataDialog() {
+    if (!this.allowMetadata()) return;
+
     this.matDialog.open(AccountMetadataDialog, {
       data: {
         metadata: this.account().metadata,

--- a/src/app/components/interest/interest-warning-button/interest-warning-button.ts
+++ b/src/app/components/interest/interest-warning-button/interest-warning-button.ts
@@ -18,7 +18,7 @@ export class InterestWarningButton {
     if (!metadata) return '-';
     if (metadata.interestRate <= 0) return '-';
 
-    const rate = (metadata.interestRate * 100.0).toFixed(1);
+    const rate = (metadata.interestRate * 100.0).toFixed(2);
     return `${rate}%`;
   });
 


### PR DESCRIPTION
This makes some polishing updates to the new account metadata feature. This polish is mostly around handling _non-savings_ accounts gracefully. For example, it doesn't make sense to have an interest rate on a cash or checking account (even though some checking accounts have a very trivial small amount of interest).