### PR TITLE
Include database ID with allocation

### DIFF
--- a/src/app/components/allocations/allocation-selector/allocation-selector.ts
+++ b/src/app/components/allocations/allocation-selector/allocation-selector.ts
@@ -134,7 +134,7 @@ export class AllocationSelector {
     const budget = this.ynabStorage.selectedBudget();
     if (budget === null) return;
 
-    const newAllocation = new SingleAllocation(budget.id, this.category().id, account.id);
+    const newAllocation = new SingleAllocation(null, budget.id, this.category().id, account.id);
     await this.firestoreStorage.upsertAllocation(newAllocation);
     this.dropdownButton.close();
   }
@@ -151,6 +151,7 @@ export class AllocationSelector {
     if (!defaultAccount) return;
 
     const allocation = new AbsoluteSplitAllocation(
+        null,
         budget.id,
         this.category().id,
         defaultAccount.id,

--- a/src/lib/accounts/account_execution_result.spec.ts
+++ b/src/lib/accounts/account_execution_result.spec.ts
@@ -94,9 +94,9 @@ function cat(id: string, balance: number): Category {
 }
 
 function single(categoryId: string, accountId: string): SingleAllocation {
-  return new SingleAllocation("fake_budget", categoryId, accountId);
+  return new SingleAllocation("fake_id", "fake_budget", categoryId, accountId);
 }
 
 function absoluteSplit(categoryId: string, entries: AbsoluteSplitEntry[], defaultCategoryId: string): AbsoluteSplitAllocation {
-  return new AbsoluteSplitAllocation("fake_budget", categoryId, defaultCategoryId, entries);
+  return new AbsoluteSplitAllocation("fake_id", "fake_budget", categoryId, defaultCategoryId, entries);
 }

--- a/src/lib/firestore/firestore_storage.ts
+++ b/src/lib/firestore/firestore_storage.ts
@@ -195,7 +195,7 @@ export class FirestoreStorage {
     this.allocationsUnsubscribe = onSnapshot(allocationsQuery, (querySnapshot) => {
       const allocations: Allocation[] = [];
       querySnapshot.forEach((doc) => {
-        allocations.push(Allocation.fromSchema(doc.data() as any));
+        allocations.push(Allocation.fromSchema(doc.id, doc.data() as any));
       });
       this.allocations.set(allocations);
     });

--- a/src/lib/models/allocation.spec.ts
+++ b/src/lib/models/allocation.spec.ts
@@ -4,6 +4,7 @@ describe('SingleAllocation', () => {
   describe('.toSchema()', () => {
     it('outputs equivalent schema', () => {
       const alloc = new SingleAllocation(
+          'fake_id',
           'fake_budget_id',
           'fake_category_id',
           'fake_account_id');
@@ -20,7 +21,7 @@ describe('SingleAllocation', () => {
 
   describe('.fromSchema()', () => {
     it('loads all data from the provided schema', () => {
-      const alloc = Allocation.fromSchema({
+      const alloc = Allocation.fromSchema('fake_id', {
         type: AllocationType.SINGLE,
         userId: 'fake_user_id',
         budgetId: 'fake_budget_id',
@@ -28,6 +29,7 @@ describe('SingleAllocation', () => {
         accountId: 'fake_account_id',
       }) as SingleAllocation;
 
+      expect(alloc.id).toEqual('fake_id');
       expect(alloc.budgetId).toEqual('fake_budget_id');
       expect(alloc.categoryId).toEqual('fake_category_id');
       expect(alloc.accountId).toEqual('fake_account_id');

--- a/src/lib/models/allocation.ts
+++ b/src/lib/models/allocation.ts
@@ -4,18 +4,24 @@
  */
 export abstract class Allocation {
   constructor(
+      readonly id: string | null,
       readonly budgetId: string,
       readonly categoryId: string) {}
 
   abstract toSchema(userId: string): AllocationSchema;
 
-  static fromSchema(schema: LegacyAllocationSchema): Allocation {
+  static fromSchema(id: string, schema: LegacyAllocationSchema): Allocation {
     switch (schema.type) {
       case undefined:
       case AllocationType.SINGLE:
-        return new SingleAllocation(schema.budgetId, schema.categoryId, schema.accountId);
+        return new SingleAllocation(
+            id,
+            schema.budgetId,
+            schema.categoryId,
+            schema.accountId);
       case AllocationType.ABSOLUTE_SPLIT:
         return new AbsoluteSplitAllocation(
+            id,
             schema.budgetId,
             schema.categoryId,
             schema.defaultAccountId,
@@ -29,10 +35,11 @@ export abstract class Allocation {
  */
 export class SingleAllocation extends Allocation {
   constructor(
+      id: string | null,
       budgetId: string,
       categoryId: string,
       readonly accountId: string) {
-    super(budgetId, categoryId);
+    super(id, budgetId, categoryId);
   }
 
   /**
@@ -52,11 +59,12 @@ export class SingleAllocation extends Allocation {
 
 export class AbsoluteSplitAllocation extends Allocation {
   constructor(
+      id: string | null,
       budgetId: string,
       categoryId: string,
       readonly defaultAccountId: string,
       readonly splits: AbsoluteSplitEntry[]) {
-    super(budgetId, categoryId);
+    super(id, budgetId, categoryId);
   }
 
   override toSchema(userId: string): AllocationSchema {


### PR DESCRIPTION
Including this ID (when it is possible) is important for individually deleting allocation items, which is a key step in the attached issue.