### PR TITLE
Fix bug where all data was always culled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ynab-allocation-manager",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ynab-allocation-manager",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@angular/cdk": "^20.0.3",
         "@angular/common": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ynab-allocation-manager",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/lib/firestore/firestore_storage.ts
+++ b/src/lib/firestore/firestore_storage.ts
@@ -222,6 +222,15 @@ export class FirestoreStorage {
    * to determine whether it is used.
    */
   private filterUnusedAllocations(allocations: Allocation[]): FilteredAllocations {
+    // Treat all allocations as valid if we don't have a list of accounts. This
+    // most likely is a transient state while we fetch accounts from YNAB.
+    if (this.ynabStorage.accounts.value().length < 1) {
+      return {
+        used: allocations,
+        unused: [],
+      };
+    }
+
     const used: Allocation[] = [];
     const unused: Allocation[] = [];
 
@@ -259,6 +268,15 @@ export class FirestoreStorage {
   }
 
   private filterUnusedAccountMetadata(metadataList: AccountMetadata[]): FilteredAccountMetadata {
+    // Treat all allocations as valid if we don't have a list of accounts. This
+    // most likely is a transient state while we fetch accounts from YNAB.
+    if (this.ynabStorage.accounts.value().length < 1) {
+      return {
+        used: metadataList,
+        unused: [],
+      };
+    }
+
     const used: AccountMetadata[] = [];
     const unused: AccountMetadata[] = [];
 


### PR DESCRIPTION
This was caused by race conditions between YNAB data loading and Firestore data loading and signal-based resources updating. If they were ever out of sync in bad ways, YnabStorage would report that the user had 0 accounts, causing all allocations to be culled.

0 accounts doesn't make sense as a state, so we just ignore that state when culling.